### PR TITLE
[SYSE-385 main] July Template application

### DIFF
--- a/.github/workflows/test-square.yml
+++ b/.github/workflows/test-square.yml
@@ -1,0 +1,382 @@
+name: Test²
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - master
+      - release-*
+env:
+  VARIATION: prod
+  BASE_REF: ${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}
+jobs:
+  test-controller-api:
+    runs-on: ubuntu-latest
+    outputs:
+      envfiles: ${{ steps.params.outputs.envfiles }}
+      pump: ${{ steps.params.outputs.pump }}
+      sink: ${{ steps.params.outputs.sink }}
+    steps:
+      - name: set params
+        id: params
+        shell: bash
+        run: |
+          set -eo pipefail
+          curl -s --retry 5 --retry-delay 10 --fail-with-body "http://tui.internal.dev.tyk.technology/v2/$VARIATION/tyk-pro/$BASE_REF/${{ github.event_name}}/api.gho" | tee -a "$GITHUB_OUTPUT"
+          if ! [[ $VARIATION =~ prod ]] ;then
+              echo "::warning file=.github/workflows/release.yml,line=24,col=1,endColumn=8::Using non-prod variation"
+              echo "### :warning: You are using VARIATION=${VARIATION} in test-controller-api" >> $GITHUB_STEP_SUMMARY
+          fi
+  api-tests:
+    needs:
+      - test-controller-api
+    runs-on: ubuntu-latest
+    env:
+      XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
+      BASE_REF: master
+    permissions:
+      id-token: write # This is required for requesting the Github JWT
+      contents: read # This is required for actions/checkout
+    strategy:
+      fail-fast: false
+      matrix:
+        envfiles: ${{ fromJson(needs.test-controller-api.outputs.envfiles) }}
+        pump: ${{ fromJson(needs.test-controller-api.outputs.pump) }}
+        sink: ${{ fromJson(needs.test-controller-api.outputs.sink) }}
+        exclude:
+          - pump: tykio/tyk-pump-docker-pub:v1.8
+            sink: $ECR/tyk-sink:master
+          - pump: $ECR/tyk-pump:master
+            sink: tykio/tyk-mdcb-docker:v2.4
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+      - name: Setup tmate session only in debug mode
+        uses: mxschmitt/action-tmate@v3
+        if: runner.debug == '1'
+        with:
+          detached: true
+          limit-access-to-actor: true
+          # Only ${{ github.actor }} has access
+          # See https://github.com/mxschmitt/action-tmate#use-registered-public-ssh-keys
+      - uses: actions/checkout@v4
+        with:
+          path: auto
+          fetch-depth: 1
+      - name: env up
+        shell: bash
+        working-directory: auto
+        id: env_up
+        env:
+          pull_policy: 'if_not_present'
+          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
+          TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
+        run: |
+          match_tag=${{steps.ecr.outputs.registry}}/tyk-pro:$BASE_REF
+          tags=($match_tag)
+          set -eaxo pipefail
+          docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${tags[0]} ${match_tag} 2>versions.env
+          echo '# alfa and beta have to come after the override
+          tyk_alfa_image=$tyk_image
+          tyk_beta_image=$tyk_image
+          ECR=${{steps.ecr.outputs.registry}}
+          tyk_pump_image=${{matrix.pump}}
+
+          tyk_sink_image=${{matrix.sink}}
+          confs_dir=./pro-ha
+          env_file=local.env' >> versions.env
+          cat ./confs/${{ matrix.envfiles.config }}.env local-${{ matrix.envfiles.db }}.env > local.env
+          echo "::group::versions"
+          cat versions.env local.env
+          echo "::endgroup::"
+          # bring up env, the project name is important
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
+          ./dash-bootstrap.sh http://localhost:3000
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
+          echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        with:
+          repository: TykTechnologies/tyk-analytics
+          path: tyk-analytics
+          token: ${{ secrets.ORG_GH_TOKEN }}
+          fetch-depth: 1
+          sparse-checkout: tests/api
+      - name: Branch for test code
+        id: timestamp
+        working-directory: tyk-analytics/tests/api
+        run: |
+          # Generate report id
+          git fetch --no-tags --depth 1 origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git switch $BASE_REF
+          echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
+      - uses: actions/setup-python@v5
+        with:
+          cache: 'pip'
+          python-version: '3.10'
+      - name: Run API tests
+        id: test_execution
+        working-directory: tyk-analytics/tests/api
+        run: |
+          pytest="pytest --ci --random-order --force-flaky --no-success-flaky-report --maxfail=3 --junitxml=${XUNIT_REPORT_PATH} --cache-clear --ignore=./tests/mdcb -v --log-cli-level=ERROR"
+          pip install -r requirements.txt
+          cat >pytest.env <<-EOF
+          TYK_TEST_BASE_URL=http://localhost:3000/
+          TYK_TEST_GW_URL=https://localhost:8080/
+          TYK_TEST_GW_1_ALFA_URL=https://localhost:8181/
+          TYK_TEST_GW_1_BETA_URL=https://localhost:8182/
+          TYK_TEST_GW_2_ALFA_URL=https://localhost:8281/
+          TYK_TEST_GW_2_BETA_URL=https://localhost:8282/
+          TYK_TEST_MONGODB=localhost:27017
+          TYK_TEST_REDIS=localhost
+          TYK_TEST_DB_ADMIN=12345
+          TYK_TEST_GW_SECRET=352d20ee67be67f6340b4c0605b044b7
+          TYK_TEST_DB_NAME=tyk_analytics
+          TYK_TEST_FEDERATION_HOST=federation
+          TYK_TEST_GRAPHQL_FAKER_HOST=graphql-faker
+          GATEWAY_CONTAINER_NAME=tyk
+          USER_API_SECRET=${{ steps.env_up.outputs.USER_API_SECRET }}
+          EOF
+          env $(cat pytest.env | xargs) $pytest -m "${{ matrix.envfiles.apimarkers }}"
+      - name: Generate metadata and upload test reports
+        id: metadata_report
+        if: always() && (steps.test_execution.conclusion != 'skipped')
+        env:
+          REPORT_NAME: ${{ github.repository }}_${{ github.run_id }}_${{ github.run_attempt }}-${{steps.timestamp.outputs.ts}}
+          METADATA_REPORT_PATH: metadata.toml
+        run: |
+          # Generate metadata report
+          set -eo pipefail
+          echo "[metadata]
+          repo = ${{ github.repository }}
+          branch = ${{ github.ref }}
+          commit = ${{ github.sha }}
+          test_suite_version = $BASE_REF
+          test_suite_name = ${{ github.job }}
+          test_suite_run = ${{ github.run_id }}-${{ github.run_attempt }}
+          db = ${{ matrix.envfiles.db }}
+          conf = ${{ matrix.envfiles.config }}
+          cache = ${{ matrix.envfiles.cache }}
+          pump_compatibility = ${{ matrix.pump }}
+          sink_compatibility = ${{ matrix.sink }}
+          " | tee ${METADATA_REPORT_PATH}
+          aws s3 cp ${XUNIT_REPORT_PATH}  s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.xml
+          aws s3 cp ${METADATA_REPORT_PATH} s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.metadata.toml
+      - name: Docker logs for all components
+        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
+        working-directory: auto
+        env:
+          pull_policy: 'if_not_present'
+          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
+          TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
+          ECR: ${{ steps.ecr.outputs.registry }}
+        run: |
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile all logs | sort > ${{ github.workspace }}/docker-compose.log
+          echo "::group::DockerLogs"
+          cat ${{ github.workspace }}/docker-compose.log
+          echo "::endgroup::"
+      - name: Upload compose logs
+        uses: actions/upload-artifact@v4
+        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
+        with:
+          name: docker-compose-logs-${{ github.job }}-${{ matrix.envfiles.db }}-${{ matrix.envfiles.conf }}-${{ github.run_id }}
+          path: ${{ github.workspace }}/docker-compose.log
+          retention-days: 3
+          overwrite: true
+  test-controller-ui:
+    runs-on: ubuntu-latest
+    outputs:
+      envfiles: ${{ steps.params.outputs.envfiles }}
+      pump: ${{ steps.params.outputs.pump }}
+      sink: ${{ steps.params.outputs.sink }}
+    steps:
+      - name: set params
+        id: params
+        shell: bash
+        run: |
+          set -eo pipefail
+          curl -s --retry 5 --retry-delay 10 --fail-with-body "http://tui.internal.dev.tyk.technology/v2/$VARIATION/tyk-pro/$BASE_REF/${{ github.event_name}}/ui.gho" | tee -a "$GITHUB_OUTPUT"
+          if ! [[ $VARIATION =~ prod ]] ;then
+              echo "::warning file=.github/workflows/release.yml,line=24,col=1,endColumn=8::Using non-prod variation"
+              echo "### :warning: You are using VARIATION=${VARIATION} in test-controller-ui" >> $GITHUB_STEP_SUMMARY
+          fi
+  ui-tests:
+    needs:
+      - test-controller-ui
+    runs-on: ubuntu-latest
+    env:
+      XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
+      BASE_REF: master
+    permissions:
+      id-token: write # This is required for requesting the Github JWT
+      contents: read # This is required for actions/checkout
+    strategy:
+      fail-fast: false
+      matrix:
+        envfiles: ${{ fromJson(needs.test-controller-ui.outputs.envfiles) }}
+        pump: ${{ fromJson(needs.test-controller-ui.outputs.pump) }}
+        sink: ${{ fromJson(needs.test-controller-ui.outputs.sink) }}
+        exclude:
+          - pump: tykio/tyk-pump-docker-pub:v1.8
+            sink: $ECR/tyk-sink:master
+          - pump: $ECR/tyk-pump:master
+            sink: tykio/tyk-mdcb-docker:v2.4
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
+          role-session-name: cipush
+          aws-region: eu-central-1
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+      - name: Setup tmate session only in debug mode
+        uses: mxschmitt/action-tmate@v3
+        if: runner.debug == '1'
+        with:
+          detached: true
+          limit-access-to-actor: true
+          # Only ${{ github.actor }} has access
+          # See https://github.com/mxschmitt/action-tmate#use-registered-public-ssh-keys
+      - uses: actions/checkout@v4
+        with:
+          path: auto
+          fetch-depth: 1
+      - name: env up
+        shell: bash
+        working-directory: auto
+        id: env_up
+        env:
+          pull_policy: 'if_not_present'
+          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
+          TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
+        run: |
+          match_tag=${{steps.ecr.outputs.registry}}/tyk-pro:$BASE_REF
+          tags=($match_tag)
+          set -eaxo pipefail
+          docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${tags[0]} ${match_tag} 2>versions.env
+          echo '# alfa and beta have to come after the override
+          tyk_alfa_image=$tyk_image
+          tyk_beta_image=$tyk_image
+          ECR=${{steps.ecr.outputs.registry}}
+          tyk_pump_image=${{matrix.pump}}
+
+          tyk_sink_image=${{matrix.sink}}
+          confs_dir=./pro-ha
+          env_file=local.env' >> versions.env
+          cat ./confs/${{ matrix.envfiles.config }}.env local-${{ matrix.envfiles.db }}.env > local.env
+          echo "::group::versions"
+          cat versions.env local.env
+          echo "::endgroup::"
+          # bring up env, the project name is important
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
+          ./dash-bootstrap.sh http://localhost:3000
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
+          echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        with:
+          repository: TykTechnologies/tyk-analytics
+          path: tyk-analytics
+          token: ${{ secrets.ORG_GH_TOKEN }}
+          fetch-depth: 1
+          sparse-checkout: tests/ui
+      - name: Branch for test code
+        id: timestamp
+        working-directory: tyk-analytics/tests/ui
+        run: |
+          # Generate report id
+          git fetch --no-tags --depth 1 origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git switch $BASE_REF
+          echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
+      - name: Install Node.js 18.16
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.16"
+          cache-dependency-path: tyk-analytics/tests/ui
+          cache: 'npm'
+      - name: Fix private module deps
+        env:
+          TOKEN: '${{ secrets.ORG_GH_TOKEN }}'
+        run: "git config --global url.\"https://${TOKEN}@github.com\".insteadOf \"https://github.com\"                    \n"
+      - name: Execute UI tests
+        working-directory: tyk-analytics/tests/ui
+        env:
+          GW_URL: 'https://localhost:8080/'
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+          UI_MARKERS: ${{ matrix.envfiles.uimarkers && format('--grep {0}', matrix.envfiles.uimarkers ) || '' }}
+        run: "npm ci\nnpx playwright install --with-deps chromium\nPLAYWRIGHT_JUNIT_OUTPUT_NAME=${XUNIT_REPORT_PATH} npx playwright test --project=chromium --reporter=junit $UI_MARKERS \n"
+      - name: Generate metadata and upload test reports
+        id: metadata_report
+        if: always() && (steps.test_execution.conclusion != 'skipped')
+        env:
+          REPORT_NAME: ${{ github.repository }}_${{ github.run_id }}_${{ github.run_attempt }}-${{steps.timestamp.outputs.ts}}
+          METADATA_REPORT_PATH: metadata.toml
+        run: |
+          # Generate metadata report
+          set -eo pipefail
+          echo "[metadata]
+          repo = ${{ github.repository }}
+          branch = ${{ github.ref }}
+          commit = ${{ github.sha }}
+          test_suite_version = $BASE_REF
+          test_suite_name = ${{ github.job }}
+          test_suite_run = ${{ github.run_id }}-${{ github.run_attempt }}
+          db = ${{ matrix.envfiles.db }}
+          conf = ${{ matrix.envfiles.config }}
+          cache = ${{ matrix.envfiles.cache }}
+          pump_compatibility = ${{ matrix.pump }}
+          sink_compatibility = ${{ matrix.sink }}
+          " | tee ${METADATA_REPORT_PATH}
+          aws s3 cp ${XUNIT_REPORT_PATH}  s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.xml
+          aws s3 cp ${METADATA_REPORT_PATH} s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.metadata.toml
+      - name: Docker logs for all components
+        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
+        working-directory: auto
+        env:
+          pull_policy: 'if_not_present'
+          GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
+          TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
+          ECR: ${{ steps.ecr.outputs.registry }}
+        run: |
+          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile all logs | sort > ${{ github.workspace }}/docker-compose.log
+          echo "::group::DockerLogs"
+          cat ${{ github.workspace }}/docker-compose.log
+          echo "::endgroup::"
+      - name: Upload compose logs
+        uses: actions/upload-artifact@v4
+        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
+        with:
+          name: docker-compose-logs-${{ github.job }}-${{ matrix.envfiles.db }}-${{ matrix.envfiles.conf }}-${{ github.run_id }}
+          path: ${{ github.workspace }}/docker-compose.log
+          retention-days: 3
+          overwrite: true
+  release:
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    runs-on: ubuntu-latest
+    needs:
+      - api-tests
+      - ui-tests
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.ORG_GH_TOKEN }}
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body_path: release.md


### PR DESCRIPTION
Test controller v2 API can output in Gihub Output format or json for v1 API endpoint.
Test controller loads all known configuration files, v2 API allows you to choose.
tyk-ci/auto → tyklabs/tyk-pro
test² tests for tyk-pro.
gromit policy match finds container image tags for changes across repos.
- [ ] Refactor tyk-analytics to run API tests from code
- [x] Images not being pushed to dockerhub on tag when distroless feature is missing
- [x] Policy match fix
- [ ] Quality gates for tyk-analitycs UI and API regression tests
- [ ] Implement custom rules for enterprise artifacts in package promotion
