### PR TITLE
[TT-17030] Migrate from ORG_GH_TOKEN PAT to GitHub App token

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -13,12 +13,20 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: AUTO env
         run: tar -czf /tmp/auto-env.tgz . && mv /tmp/auto-env.tgz .
       - uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           body_path: release.md


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` in `release-auto.yml` (`softprops/action-gh-release` token parameter) with a token generated by `actions/create-github-app-token`

### Files changed
- `.github/workflows/release-auto.yml` — release job's `softprops/action-gh-release` token

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` org-level secrets are available to this repo
- [ ] Push a tag and confirm the release workflow creates a GitHub release successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)