### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/test-square.yml
+++ b/.github/workflows/test-square.yml
@@ -396,7 +396,7 @@ jobs:
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Execute UI tests
         working-directory: tyk-analytics/tests/ui
         id: test_execution


### PR DESCRIPTION
## Summary
- Fix `git config insteadOf` pattern in `test-square.yml` to use `x-access-token:` prefix and trailing slashes
- The bare token pattern fails when `actions/checkout` has set up a credential helper; the `x-access-token:` prefix ensures the URL rewrite takes precedence

## Files changed
- `.github/workflows/test-square.yml` — 1 replacement

## Test plan
- [ ] Verify test-square workflow resolves private Go module deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)