### PR TITLE
[TT-17339 main] Implement Floating tags in github actions

### DIFF
--- a/.github/workflows/test-square.yml
+++ b/.github/workflows/test-square.yml
@@ -9,46 +9,29 @@ on:
     branches:
       - master
       - release-*
-permissions:
-  contents: read
 env:
   VARIATION: prod-variation
   BASE_REF: ${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}
 jobs:
   test-controller-api:
     if: github.event.pull_request.draft == false
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
     outputs:
       envfiles: ${{ steps.params.outputs.envfiles }}
       pump: ${{ steps.params.outputs.pump }}
       sink: ${{ steps.params.outputs.sink }}
     steps:
-      - name: set params
+      - name: Set test parameters
+        uses: TykTechnologies/github-actions/.github/actions/tests/test-controller@production
         id: params
-        shell: bash
-        run: |
-          REF=$BASE_REF
-          # Fallback to master for feature branches (anything that isn't a release branch)
-          if [[ ! "$REF" =~ ^release-.* ]]; then
-            REF="master"
-          fi
-          
-          EVENT_NAME=${{ github.event_name }}
-          # Fallback to pull_request for manual triggers
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            EVENT_NAME="pull_request"
-          fi
-          
-          # SECURITY: curl output piped to GITHUB_OUTPUT -- ensure tyktechnologies.github.io is trusted
-          curl -s -L --retry 5 --retry-delay 10 --fail-with-body "https://tyktechnologies.github.io/gromit/v2/$VARIATION/tyk-pro/$REF/$EVENT_NAME/api.gho" | tee -a "$GITHUB_OUTPUT"
-          if ! [[ $VARIATION =~ prod ]] ;then
-              echo "::warning file=.github/workflows/release.yml,line=24,col=1,endColumn=8::Using non-prod variation"
-              echo "### :warning: You are using VARIATION=${VARIATION} in test-controller-api" >> $GITHUB_STEP_SUMMARY
-          fi
+        with:
+          variation: ${{ env.VARIATION }}
+          base_ref: ${{ env.BASE_REF }}
+          test_type: api
   api-tests:
     needs:
       - test-controller-api
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
     env:
       XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
       BASE_REF: master
@@ -74,14 +57,13 @@ jobs:
           app-id: ${{ secrets.PROBE_APP_ID }}
           private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
           owner: TykTechnologies
-
       - uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
           role-session-name: cipush
           aws-region: eu-central-1
       - id: ecr
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         with:
           mask-password: 'true'
       - name: Setup tmate session only in debug mode
@@ -96,183 +78,52 @@ jobs:
         with:
           path: auto
           fetch-depth: 1
-      - name: env up
-        shell: bash
-        working-directory: auto
+      - name: Set up test environment
+        uses: TykTechnologies/github-actions/.github/actions/tests/env-up@production
+        timeout-minutes: 5
         id: env_up
-        env:
-          pull_policy: 'if_not_present'
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          base_ref: ${{ env.BASE_REF }}
+          tags: ${{ needs.goreleaser.outputs.ee_tags || needs.goreleaser.outputs.std_tags || format('{0}/tyk-ee:master', steps.ecr.outputs.registry) }}
+          github_token: ${{ steps.app-token.outputs.token }}
           TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
-        run: |
-          match_tag=${{steps.ecr.outputs.registry}}/tyk-pro:$BASE_REF
-          tags=($match_tag)
-          set -eaxo pipefail
-          docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${tags[0]} ${match_tag} 2>versions.env
-          echo '# alfa and beta have to come after the override
-
-          tyk_image="$ECR/tyk-ee"
-          tyk_alfa_image=$tyk_image
-          tyk_beta_image=$tyk_image
-          ECR=${{steps.ecr.outputs.registry}}
-          tyk_pump_image=${{matrix.pump}}
-
-          tyk_sink_image=${{matrix.sink}}
-          confs_dir=./pro-ha
-          env_file=local.env' >> versions.env
-          cat ./confs/${{ matrix.envfiles.config }}.env local-${{ matrix.envfiles.db }}.env > local.env
-          echo "::group::versions"
-          cat versions.env local.env
-          echo "::endgroup::"
-          # bring up env, the project name is important
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
-          ./dash-bootstrap.sh http://localhost:3000
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
-          echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
-          echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Choose test code branch
+        uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@production
         with:
-          repository: TykTechnologies/tyk-analytics
-          path: tyk-analytics
-          token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 0
-          sparse-checkout: tests/api
-      - name: Choosing test code branch
-        working-directory: tyk-analytics/tests/api
-        run: |
-          if [[ ${{ github.event_name }} == "pull_request" ]]; then
-            PR_BRANCH=${{ github.event.pull_request.head.ref }}
-            TARGET_BRANCH=${{ github.event.pull_request.base.ref }}
-            echo "Looking for PR_BRANCH:$PR_BRANCH or TARGET_BRANCH:$TARGET_BRANCH..."
-            if git rev-parse --verify "origin/$PR_BRANCH" >/dev/null 2>&1; then
-              echo "PR branch $PR_BRANCH exists. Checking out..."
-              git checkout "$PR_BRANCH"
-            elif git rev-parse --verify "origin/$TARGET_BRANCH" >/dev/null 2>&1; then
-              echo "Target branch $TARGET_BRANCH exists. Checking out..."
-              git checkout "$TARGET_BRANCH"
-            fi
-          fi
-          if [[ ${{ github.event_name }} == "push" ]]; then
-            PUSH_BRANCH=${{ github.ref_name }}
-            echo "Looking for PUSH_BRANCH:$PUSH_BRANCH..."
-            if git rev-parse --verify "origin/$PUSH_BRANCH" >/dev/null 2>&1; then
-              echo "Push branch $PUSH_BRANCH exists. Checking out..."
-              git checkout "$PUSH_BRANCH"
-            fi
-          fi
-          echo "Current commit: $(git rev-parse HEAD)"
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          cache: 'pip'
-          python-version: '3.10'
+          test_folder: api
+          org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Run API tests
+        uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@production
+        timeout-minutes: 45
         id: test_execution
-        working-directory: tyk-analytics/tests/api
-        run: |
-          pytest="pytest --ci --random-order --force-flaky --no-success-flaky-report --maxfail=3 --junitxml=${XUNIT_REPORT_PATH} --cache-clear --ignore=./tests/mdcb -v --log-cli-level=ERROR"
-          pip install --no-deps -r requirements.txt
-          cat >pytest.env <<-EOF
-          TYK_TEST_BASE_URL=http://localhost:3000/
-          TYK_TEST_GW_URL=https://localhost:8080/
-          TYK_TEST_GW_1_ALFA_URL=https://localhost:8181/
-          TYK_TEST_GW_1_BETA_URL=https://localhost:8182/
-          TYK_TEST_GW_2_ALFA_URL=https://localhost:8281/
-          TYK_TEST_GW_2_BETA_URL=https://localhost:8282/
-          TYK_TEST_MONGODB=localhost:27017
-          TYK_TEST_REDIS=localhost
-          TYK_TEST_DB_ADMIN=12345
-          TYK_TEST_GW_SECRET=352d20ee67be67f6340b4c0605b044b7
-          TYK_TEST_DB_NAME=tyk_analytics
-          TYK_TEST_FEDERATION_HOST=federation
-          TYK_TEST_GRAPHQL_FAKER_HOST=graphql-faker
-          GATEWAY_CONTAINER_NAME=tyk
-          USER_API_SECRET=${{ steps.env_up.outputs.USER_API_SECRET }}
-          TYK_TEST_KEYCLOAK_INTERNAL_URL=http://keycloak:8080
-          TYK_TEST_MCP_URL=http://mcp-server:7878
-          EOF
-          env $(cat pytest.env | xargs) $pytest -m "${{ matrix.envfiles.apimarkers }}"
-      - name: Generate metadata and upload test reports
-        id: metadata_report
-        if: always() && (steps.test_execution.conclusion != 'skipped')
-        env:
-          REPORT_NAME: ${{ github.repository }}_${{ github.run_id }}_${{ github.run_attempt }}-${{steps.env_up.outputs.ts}}
-          METADATA_REPORT_PATH: metadata.toml
-        run: |
-          # Generate metadata report
-          set -eo pipefail
-          echo "[metadata]
-          repo = ${{ github.repository }}
-          branch = ${{ github.ref }}
-          commit = ${{ github.sha }}
-          test_suite_version = $BASE_REF
-          test_suite_name = ${{ github.job }}
-          test_suite_run = ${{ github.run_id }}-${{ github.run_attempt }}
-          db = ${{ matrix.envfiles.db }}
-          conf = ${{ matrix.envfiles.config }}
-          cache = ${{ matrix.envfiles.cache }}
-          pump_compatibility = ${{ matrix.pump }}
-          sink_compatibility = ${{ matrix.sink }}
-          " | tee ${METADATA_REPORT_PATH}
-          aws s3 cp ${XUNIT_REPORT_PATH}  s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.xml
-          aws s3 cp ${METADATA_REPORT_PATH} s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.metadata.toml
-      - name: Docker logs for all components
-        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
-        working-directory: auto
-        env:
-          pull_policy: 'if_not_present'
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
-          TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
-          ECR: ${{ steps.ecr.outputs.registry }}
-        run: |
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile all logs | sort > ${{ github.workspace }}/docker-compose.log
-          echo "::group::DockerLogs"
-          cat ${{ github.workspace }}/docker-compose.log
-          echo "::endgroup::"
-      - name: Upload compose logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
         with:
-          name: docker-compose-logs-${{ github.job }}-${{ matrix.envfiles.db }}-${{ matrix.envfiles.conf }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/docker-compose.log
-          retention-days: 3
-          overwrite: true
+          user_api_secret: ${{ steps.env_up.outputs.USER_API_SECRET }}
+      - name: Generate test reports and collect logs
+        uses: TykTechnologies/github-actions/.github/actions/tests/reporting@production
+        if: always() && (steps.test_execution.conclusion != 'skipped')
+        with:
+          report_xml: 'true'
+          execution_status: ${{ steps.test_execution.outcome }}
   test-controller-ui:
     if: github.event.pull_request.draft == false
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
     outputs:
       envfiles: ${{ steps.params.outputs.envfiles }}
       pump: ${{ steps.params.outputs.pump }}
       sink: ${{ steps.params.outputs.sink }}
     steps:
-      - name: set params
+      - name: Set test parameters
+        uses: TykTechnologies/github-actions/.github/actions/tests/test-controller@production
         id: params
-        shell: bash
-        run: |
-          set -eo pipefail
-          REF=$BASE_REF
-          # Fallback to master for feature branches (anything that isn't a release branch)
-          if [[ ! "$REF" =~ ^release-.* ]]; then
-            REF="master"
-          fi
-          
-          EVENT_NAME=${{ github.event_name }}
-          # Fallback to pull_request for manual triggers
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            EVENT_NAME="pull_request"
-          fi
-          
-          # SECURITY: curl output piped to GITHUB_OUTPUT -- ensure tyktechnologies.github.io is trusted
-          curl -s -L --retry 5 --retry-delay 10 --fail-with-body "https://tyktechnologies.github.io/gromit/v2/$VARIATION/tyk-pro/$REF/$EVENT_NAME/ui.gho" | tee -a "$GITHUB_OUTPUT"
-          if ! [[ $VARIATION =~ prod ]] ;then
-              echo "::warning file=.github/workflows/release.yml,line=24,col=1,endColumn=8::Using non-prod variation"
-              echo "### :warning: You are using VARIATION=${VARIATION} in test-controller-ui" >> $GITHUB_STEP_SUMMARY
-          fi
+        with:
+          variation: ${{ env.VARIATION }}
+          base_ref: ${{ env.BASE_REF }}
+          test_type: ui
   ui-tests:
     needs:
       - test-controller-ui
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
     env:
       XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
       BASE_REF: master
@@ -298,14 +149,13 @@ jobs:
           app-id: ${{ secrets.PROBE_APP_ID }}
           private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
           owner: TykTechnologies
-
       - uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: arn:aws:iam::754489498669:role/ecr_rw_tyk
           role-session-name: cipush
           aws-region: eu-central-1
       - id: ecr
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         with:
           mask-password: 'true'
       - name: Setup tmate session only in debug mode
@@ -320,154 +170,46 @@ jobs:
         with:
           path: auto
           fetch-depth: 1
-      - name: env up
-        shell: bash
-        working-directory: auto
+      - name: Set up test environment
+        uses: TykTechnologies/github-actions/.github/actions/tests/env-up@production
+        timeout-minutes: 5
         id: env_up
-        env:
-          pull_policy: 'if_not_present'
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          base_ref: ${{ env.BASE_REF }}
+          tags: ${{ needs.goreleaser.outputs.ee_tags || needs.goreleaser.outputs.std_tags || format('{0}/tyk-ee:master', steps.ecr.outputs.registry) }}
+          github_token: ${{ steps.app-token.outputs.token }}
           TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
-        run: |
-          match_tag=${{steps.ecr.outputs.registry}}/tyk-pro:$BASE_REF
-          tags=($match_tag)
-          set -eaxo pipefail
-          docker run -q --rm -v ~/.docker/config.json:/root/.docker/config.json tykio/gromit policy match ${tags[0]} ${match_tag} 2>versions.env
-          echo '# alfa and beta have to come after the override
-
-          tyk_image="$ECR/tyk-ee"
-          tyk_alfa_image=$tyk_image
-          tyk_beta_image=$tyk_image
-          ECR=${{steps.ecr.outputs.registry}}
-          tyk_pump_image=${{matrix.pump}}
-
-          tyk_sink_image=${{matrix.sink}}
-          confs_dir=./pro-ha
-          env_file=local.env' >> versions.env
-          cat ./confs/${{ matrix.envfiles.config }}.env local-${{ matrix.envfiles.db }}.env > local.env
-          echo "::group::versions"
-          cat versions.env local.env
-          echo "::endgroup::"
-          # bring up env, the project name is important
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
-          ./dash-bootstrap.sh http://localhost:3000
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
-          echo "$(cat pytest.env | grep USER_API_SECRET)" >> $GITHUB_OUTPUT
-          echo "ts=$(date +%s%N)" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Choose test code branch
+        uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@production
         with:
-          repository: TykTechnologies/tyk-analytics
-          path: tyk-analytics
-          token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 0
-          sparse-checkout: tests/ui
-      - name: Choosing test code branch
-        working-directory: tyk-analytics/tests/ui
-        run: |
-          if [[ ${{ github.event_name }} == "pull_request" ]]; then
-            PR_BRANCH=${{ github.event.pull_request.head.ref }}
-            TARGET_BRANCH=${{ github.event.pull_request.base.ref }}
-            echo "Looking for PR_BRANCH:$PR_BRANCH or TARGET_BRANCH:$TARGET_BRANCH..."
-            if git rev-parse --verify "origin/$PR_BRANCH" >/dev/null 2>&1; then
-              echo "PR branch $PR_BRANCH exists. Checking out..."
-              git checkout "$PR_BRANCH"
-            elif git rev-parse --verify "origin/$TARGET_BRANCH" >/dev/null 2>&1; then
-              echo "Target branch $TARGET_BRANCH exists. Checking out..."
-              git checkout "$TARGET_BRANCH"
-            fi
-          fi
-          if [[ ${{ github.event_name }} == "push" ]]; then
-            PUSH_BRANCH=${{ github.ref_name }}
-            echo "Looking for PUSH_BRANCH:$PUSH_BRANCH..."
-            if git rev-parse --verify "origin/$PUSH_BRANCH" >/dev/null 2>&1; then
-              echo "Push branch $PUSH_BRANCH exists. Checking out..."
-              git checkout "$PUSH_BRANCH"
-            fi
-          fi
-          echo "Current commit: $(git rev-parse HEAD)"
-      - name: Install Node.js 18.16
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "18.16"
-          cache-dependency-path: tyk-analytics/tests/ui
-          cache: 'npm'
+          test_folder: ui
+          org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Fix private module deps
         env:
-          TOKEN: ${{ steps.app-token.outputs.token }}
+          TOKEN: '${{ steps.app-token.outputs.token }}'
         run: >
           git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Execute UI tests
-        working-directory: tyk-analytics/tests/ui
+        timeout-minutes: 30
+        uses: TykTechnologies/github-actions/.github/actions/tests/ui-tests@production
         id: test_execution
-        env:
-          GW_URL: 'https://localhost:8080/'
-          NODE_TLS_REJECT_UNAUTHORIZED: 0
-          UI_MARKERS: ${{ matrix.envfiles.uimarkers && format('--grep {0}', matrix.envfiles.uimarkers ) || '' }}
-        run: "npm ci\nnpx playwright install --with-deps chromium\nPLAYWRIGHT_JUNIT_OUTPUT_NAME=${XUNIT_REPORT_PATH} npx playwright test --project=chromium --reporter=junit,html $UI_MARKERS \n"
-      - name: Upload Playwright Test Report to S3
+      - name: Upload UI test report to S3
+        uses: TykTechnologies/github-actions/.github/actions/tests/ui-tests-report@production
         if: failure() && steps.test_execution.outcome != 'success' && steps.env_up.outcome == 'success'
-        run: npm run upload_report_to_s3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.UI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.UI_AWS_SECRET_ACCESS_KEY }}
-          RUN_ID: 'tyk-analytics/${{ github.run_id }}'
-        working-directory: tyk-analytics/tests/ui
-      - name: Share S3 report link into summary
-        if: failure() && steps.test_execution.outcome != 'success' && steps.env_up.outcome == 'success'
-        run: |
-          echo "# :clipboard: S3 UI Test REPORT: ${{ matrix.envfiles.db }}-${{ matrix.envfiles.conf }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Status: ${{ steps.test_execution.outcome == 'success' && ':white_check_mark:' || ':no_entry_sign:' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- [Link to report](https://tyk-qa-reports.s3.eu-central-1.amazonaws.com/tyk-analytics/${{ github.run_id }}/index.html)" >> $GITHUB_STEP_SUMMARY
-      - name: Generate metadata and upload test reports
-        id: metadata_report
-        if: always() && (steps.test_execution.conclusion != 'skipped')
-        env:
-          REPORT_NAME: ${{ github.repository }}_${{ github.run_id }}_${{ github.run_attempt }}-${{steps.env_up.outputs.ts}}
-          METADATA_REPORT_PATH: metadata.toml
-        run: |
-          # Generate metadata report
-          set -eo pipefail
-          echo "[metadata]
-          repo = ${{ github.repository }}
-          branch = ${{ github.ref }}
-          commit = ${{ github.sha }}
-          test_suite_version = $BASE_REF
-          test_suite_name = ${{ github.job }}
-          test_suite_run = ${{ github.run_id }}-${{ github.run_attempt }}
-          db = ${{ matrix.envfiles.db }}
-          conf = ${{ matrix.envfiles.config }}
-          cache = ${{ matrix.envfiles.cache }}
-          pump_compatibility = ${{ matrix.pump }}
-          sink_compatibility = ${{ matrix.sink }}
-          " | tee ${METADATA_REPORT_PATH}
-          aws s3 cp ${XUNIT_REPORT_PATH}  s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.xml
-          aws s3 cp ${METADATA_REPORT_PATH} s3://assets.dev.tyk.technology/testreports/${REPORT_NAME#*/}.metadata.toml
-      - name: Docker logs for all components
-        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
-        working-directory: auto
-        env:
-          pull_policy: 'if_not_present'
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
-          TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
-          ECR: ${{ steps.ecr.outputs.registry }}
-        run: |
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f ${{ matrix.envfiles.db }}.yml -f ${{ matrix.envfiles.cache }}.yml --env-file versions.env --profile all logs | sort > ${{ github.workspace }}/docker-compose.log
-          echo "::group::DockerLogs"
-          cat ${{ github.workspace }}/docker-compose.log
-          echo "::endgroup::"
-      - name: Upload compose logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: failure() && (steps.test_execution.outcome != 'success' || steps.env_up.outcome != 'success')
         with:
-          name: docker-compose-logs-${{ github.job }}-${{ matrix.envfiles.db }}-${{ matrix.envfiles.conf }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/docker-compose.log
-          retention-days: 3
-          overwrite: true
+          aws_acces_key_id: ${{ secrets.UI_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.UI_AWS_SECRET_ACCESS_KEY }}
+      - name: Generate test reports and collect logs
+        uses: TykTechnologies/github-actions/.github/actions/tests/reporting@production
+        if: always() && (steps.test_execution.conclusion != 'skipped')
+        with:
+          report_xml: 'true'
+          execution_status: ${{ steps.test_execution.outcome }}
   release:
     if: ${{ startsWith(github.ref, 'refs/tags') }}
-    runs-on: warp-ubuntu-latest-x64-4x
+    # Backticks escape GitHub Actions syntax from Go template parsing
+    runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - api-tests
       - ui-tests
@@ -481,7 +223,6 @@ jobs:
           app-id: ${{ secrets.PROBE_APP_ID }}
           private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
           owner: TykTechnologies
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:


### PR DESCRIPTION
Maintain a mutable tag (e.g. production) in the GitHub Actions repo, moved to the latest commit. Product repos reference @production and pick up updates automatically.
This is a follow up of the Spike ticket: https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/451?assignee=5ed4afcb53ec400c2c067d80&selectedIssue=TT-17303 
