### PR TITLE
[TT-17633] Add local nginx alias for wrong.host.badssl.com

### DIFF
--- a/deps_pro-ha.yml
+++ b/deps_pro-ha.yml
@@ -74,6 +74,10 @@ services:
       - ./confs/nginx.conf:/etc/nginx/nginx.conf
       - ./certs/nginx.crt:/etc/nginx/ssl/nginx.crt
       - ./certs/nginx.key:/etc/nginx/ssl/nginx.key
+    networks:
+      default:
+        aliases:
+          - wrong.host.badssl.com
     depends_on:
       - upstream
 

--- a/deps_pro.yml
+++ b/deps_pro.yml
@@ -75,6 +75,10 @@ services:
       - ./confs/nginx.conf:/etc/nginx/nginx.conf
       - ./certs/nginx.crt:/etc/nginx/ssl/nginx.crt
       - ./certs/nginx.key:/etc/nginx/ssl/nginx.key
+    networks:
+      default:
+        aliases:
+          - wrong.host.badssl.com
     depends_on:
       - upstream
 


### PR DESCRIPTION
Adds wrong.host.badssl.com as a Docker network alias to the existing nginx service, so SSL hostname-mismatch tests run against a local container instead of the public badssl.com site.

The nginx cert (CN=nginx) intentionally mismatches the alias hostname, reproducing the same SSL validation failure scenario. This eliminates a flaky external dependency that caused intermittent failures in [test_api_definition_with_ssl_validation_positive/negative](https://github.com/TykTechnologies/tyk-analytics/blob/892359d98e637ba795d4a4cb144f7b76de11ff29/tests/api/tests/dashboard_api/end_to_end_api_test.py#L1962) when badssl.com was unreachable or slow.

No test code changes required. No impact on other tests using the nginx service.