### PR TITLE
fix: add restart policy to openldap to survive intermittent slapd startup failure

### DIFF
--- a/deps_pro-ha.yml
+++ b/deps_pro-ha.yml
@@ -21,6 +21,10 @@ services:
     profiles: ["all", "master-datacenter"]
     container_name: openldap
     image: osixia/openldap:1.5.0
+    # osixia/openldap intermittently fails its first slapd start
+    # ("/container/run/startup/slapd failed with status 255"), leaving LDAP
+    # dead for the whole session and breaking TIB SSO api-tests. Retry it.
+    restart: on-failure
     ports:
       - "389:389"
       - "636:636"

--- a/deps_pro.yml
+++ b/deps_pro.yml
@@ -22,6 +22,10 @@ services:
     profiles: ["all", "master-datacenter"]
     container_name: openldap
     image: osixia/openldap:1.5.0
+    # osixia/openldap intermittently fails its first slapd start
+    # ("/container/run/startup/slapd failed with status 255"), leaving LDAP
+    # dead for the whole session and breaking TIB SSO api-tests. Retry it.
+    restart: on-failure
     ports:
       - "389:389"
       - "636:636"


### PR DESCRIPTION
## Summary

Adds `restart: on-failure` to the `openldap` service in `deps_pro.yml` and `deps_pro-ha.yml` (the only two files using `osixia/openldap:1.5.0`).

## Why

`osixia/openldap:1.5.0` intermittently fails its first slapd start (`*** ERROR ... /container/run/startup/slapd failed with status 255` — a long-standing issue in that unmaintained image). With no restart policy, LDAP stays dead for the entire session, and `tib_test.py::TestTib::test_end_to_end_tib_login` fails all its retries with "SSO over TIB does not work!", blocking merges in tyk-analytics.

Recent hits of this exact signature:
- tyk-analytics master: https://github.com/TykTechnologies/tyk-analytics/actions/runs/29424778111 (Jul 15, redis7/mongo7 row)
- tyk-analytics PR #5917: https://github.com/TykTechnologies/tyk-analytics/actions/runs/29480036268 (Jul 16, valkey9_1/postgres15 row)

Same run, sibling matrix row where openldap started fine: test passes — confirming it's purely the container startup lottery.

## Why this fix is sufficient

A restart policy retries the failed init, and the TIB test already has a 5-attempt exponential-backoff retry loop (tyk-analytics #5861 / TT-17616) that absorbs the extra startup time. No image swap or healthcheck orchestration needed; `restart:` is already used elsewhere in `deps_pro.yml`.

Note: CI consumes the tyk-pro release tarball, so a new release is needed after merge before the api-tests environments pick this up.

## Verification

- Both files parse as valid YAML; `docker compose -f deps_pro.yml config --quiet` passes (only the pre-existing obsolete `version:` warning).
