### PR TITLE
TT-17949: Restore the k8s httpbin upstream in the tools namespace

### DIFF
--- a/k8s/apps/README.md
+++ b/k8s/apps/README.md
@@ -4,6 +4,13 @@ This directory contains Kubernetes manifests for auxiliary applications that sup
 
 ## Files
 
+- `httpbin.yaml` - Go implementation of httpbin.org for testing HTTP requests and responses
+  - Based on the [go-httpbin](https://github.com/mccutchen/go-httpbin) project
+  - Deployed into the `tools` namespace and used as the upstream for the api tests
+    via `TYK_TEST_UPSTREAM_URL=http://httpbin.tools.svc.cluster.local:8080/`
+  - Includes readiness and liveness probes to ensure the application is healthy
+  - Runs on port 8080
+
 - `k6.yaml` - k6 load testing tool configuration for performance testing
   - References the external script file `test-script.js`
   - When applying this manifest, use: `kubectl create configmap k6-test-script --from-file=test-script.js=./k8s/apps/test-script.js -n tools`

--- a/k8s/apps/httpbin.yaml
+++ b/k8s/apps/httpbin.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: tools
+  labels:
+    app: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+      - name: httpbin
+        image: mccutchen/go-httpbin:2.18.3
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /get
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /get
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: tools
+spec:
+  selector:
+    app: httpbin
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: ClusterIP

--- a/k8s/tyk-stack-ingress/run-tyk-cp-dp.sh
+++ b/k8s/tyk-stack-ingress/run-tyk-cp-dp.sh
@@ -405,6 +405,13 @@ done
 log "Creating $TOOLS_NAMESPACE namespace"
 kubectl create namespace "$TOOLS_NAMESPACE" 2> /dev/null || true
 
+# httpbin is the upstream the api tests point at via TYK_TEST_UPSTREAM_URL
+# (http://httpbin.tools.svc.cluster.local:8080/). Without it the gateways answer
+# 500 "Upstream host lookup failed". TT-17949
+log "Installing httpbin app in $TOOLS_NAMESPACE namespace"
+kubectl apply -f ../apps/httpbin.yaml
+kubectl -n "$TOOLS_NAMESPACE" rollout status deployment/httpbin --timeout=120s
+log "Successfully installed httpbin"
 
 log "Installing k6 load testing resources in $TOOLS_NAMESPACE namespace"
 kubectl create configmap k6-test-script --from-file=test-script.js=../apps/test-script.js \


### PR DESCRIPTION
## Description

Restores `k8s/apps/httpbin.yaml` and the step that applies it in `k8s/tyk-stack-ingress/run-tyk-cp-dp.sh`.

`DX-2386` (2d71470, 6 July) reverted the httpbin test-infra migration and deleted the k8s manifest along with its two `kubectl apply` lines. The follow-up restore (85fc71b, #98) only brought back the **docker-compose** containers — `deps_pro.yml`, `deps_pro-ha.yml`, `confs/nginx.conf`, `pytest.env` — so the k8s side has had no upstream since then.

tyk-analytics' `k8s-api-tests` workflow still points the tests at `TYK_TEST_UPSTREAM_URL=http://httpbin.tools.svc.cluster.local:8080/`, so nothing resolves that name and the gateways answer `500 "Upstream host lookup failed"`.

Evidence — the k8s resilience jobs, all three versions in the matrix, e.g. [run 31344646657](https://github.com/TykTechnologies/tyk-analytics/actions/runs/31344646657):

```
FAILED resilience/mdcb_down_test.py::TestCRUDonAPIdefinition::test_mdcb_down
  AssertionError: Wrong response code: 500 (expected: 200) on response {
      "error": "Upstream host lookup failed"
  }
```

## Changes

- `k8s/apps/httpbin.yaml` — restored verbatim from `2d71470^`: `mccutchen/go-httpbin:2.18.3`, Deployment + ClusterIP Service named `httpbin` in namespace `tools`, port 8080. The DNS name and port the workflow expects both match, so this does not reintroduce the port mismatch fixed in #93.
- `run-tyk-cp-dp.sh` — re-added the apply step after the `tools` namespace is created, plus a `rollout status --timeout=120s` the original did not have, so tests cannot start against a pod that is not ready. `TOOLS_NAMESPACE="tools"` and the namespace creation were untouched by the revert, so nothing else was needed.
- `k8s/apps/README.md` — restored the entry, now naming the env var that consumes it.

## How this has been tested

`bash -n` on the modified script. Not yet exercised against a live cluster — the k8s pipeline lives in tyk-analytics, so the real verification is the `k8s-api-tests` run on TykTechnologies/tyk-analytics#6085 once this merges.

## Related

TT-17949. Paired with a tyk-analytics PR that fixes the second cause of the same red jobs (the suites were running under `-n auto` and deleting each other's APIs). Both are needed; neither alone turns the resilience suite green.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)