### PR TITLE
[TT-17949] Route CP gateway -> dashboard via toxiproxy, shorten DP RPC call timeout

### DIFF
--- a/k8s/tyk-stack-ingress/helmfile.yaml.gotmpl
+++ b/k8s/tyk-stack-ingress/helmfile.yaml.gotmpl
@@ -144,8 +144,10 @@ releases:
         value: toxiproxy.toxiproxy.svc:{{ index $ports "redisCP" }}
       - name: global.mongo.mongoURL
         value: mongodb://toxiproxy.toxiproxy.svc:{{ index $ports "mongo" }}/tyk_analytics
+        # Routed via toxiproxy so resilience tests can sever the gateway -> dashboard
+        # link and observe the "dashboard" component fail on the gateway's /hello.
       - name: tyk-gateway.gateway.useDashboardAppConfig.dashboardConnectionString
-        value: http://dashboard-svc-tyk-control-plane-{{ $name }}-tyk-dashboard.{{ $cpNamespace }}.svc:3000
+        value: http://toxiproxy.toxiproxy.svc:{{ index $ports "dashboard" }}
         {{- else }}
       - name: global.redis.addrs[0]
         value: redis.{{ $cpNamespace }}.svc:6379

--- a/k8s/tyk-stack-ingress/helmfile.yaml.gotmpl
+++ b/k8s/tyk-stack-ingress/helmfile.yaml.gotmpl
@@ -220,6 +220,19 @@ releases:
     values:
       - ./manifests/data-plane-values.yaml
       - ./versions/{{ $name }}/dp-values.yaml
+      {{- if $useToxiproxy }}
+      # Gateway <= 5.11.x gathers its health checks under a bare wg.Wait(), so a
+      # blocked RPC login freezes the whole /hello snapshot -- a severed MDCB
+      # link keeps reporting the stale "rpc: pass" for minutes. Every gorpc call
+      # is bounded by SlaveOptions.CallTimeout (30s by default, x4 login
+      # attempts), so shorten it here to let resilience tests observe the
+      # failure. Inline values rather than `set:` so "5" stays a string.
+      - tyk-gateway:
+          gateway:
+            extraEnvs:
+              - name: TYK_GW_SLAVEOPTIONS_CALLTIMEOUT
+                value: "5"
+      {{- end }}
     set:
       - name: global.remoteControlPlane.useSecretName
         value: tyk-data-plane-secret


### PR DESCRIPTION
Two fixes that together let resilience tests observe control-plane dependency failures on the gateway's `/hello`.

## 1. Route CP gateway -> dashboard via toxiproxy

In the `useToxiproxy` branch, redis and mongo were rewired through toxiproxy but `useDashboardAppConfig.dashboardConnectionString` still pointed straight at the dashboard service — byte-identical to the non-toxiproxy branch.

Toxiproxy only intercepts traffic from clients configured to dial it, so disabling the `dashboard` proxy was a no-op for the gateway: `DashService.Ping()` kept succeeding and `/hello` always reported `dashboard: pass`.

```diff
       - name: tyk-gateway.gateway.useDashboardAppConfig.dashboardConnectionString
-        value: http://dashboard-svc-tyk-control-plane-{{ $name }}-tyk-dashboard.{{ $cpNamespace }}.svc:3000
+        value: http://toxiproxy.toxiproxy.svc:{{ index $ports "dashboard" }}
```

No new plumbing: the `dashboard` key already exists in every `versions/*/.ports.yaml` and `toxiproxy-agent/cli.py` already creates a matching proxy.

**Verified working** — the previously-failing `test_cp_gateway_hello_with_dashboard_down` passes with this change.

## 2. Shorten the DP RPC call timeout

Gateway <= 5.11.x gathers health checks under a bare `wg.Wait()` (the timeout barrier only landed on master). A blocked RPC login therefore freezes the *entire* `/hello` snapshot. With the default 30s `SlaveOptions.CallTimeout` and four login attempts, severing the MDCB link left the gateway serving a stale `rpc: pass` for minutes:

```
09:06:29 error "RPC Login failed" error="gorpc.Client: [toxiproxy.toxiproxy.svc:29091].
                                   Cannot obtain response during timeout=30s"
```

Setting `TYK_GW_SLAVEOPTIONS_CALLTIMEOUT=5` on data plane gateways, toxiproxy topology only, makes the login fail fast so the snapshot turns over in ~35s. It also shortens how long a data plane stays cut off, which should reduce knock-on flakiness in later tests.

Declared via inline `values:` rather than `set:` so the value stays a string — `helm --set` would coerce it to an int and the env var would be rejected.

## Verification

`helmfile template` with `useToxiproxy=true`:
- `TYK_GW_DBAPPCONFOPTIONS_CONNECTIONSTRING: "http://toxiproxy.toxiproxy.svc:23000"`
- `TYK_GW_SLAVEOPTIONS_CALLTIMEOUT: "5"` (quoted)

Without `useToxiproxy`, neither change appears — normal runs are untouched.

## Risk

`cp_down_test.py` also disables the `dashboard` proxy. Previously the CP gateway didn't notice; now it will also lose its dashboard link. That test only asserts the *data plane* gateways keep serving traffic, which shouldn't depend on the CP gateway — but it's the one to watch.

## Testing

Being validated against [tyk-analytics#5810](https://github.com/TykTechnologies/tyk-analytics/pull/5810), which temporarily pins its tyk-pro checkout to this branch. **Do not merge until that run is green**, and the pin must be removed from that PR before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
