### PR TITLE
[TT-17949] Honour image overrides so the k8s version matrix is real

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 __pycache__*
 .ports.yaml
+.images.yaml

--- a/k8s/tyk-stack-ingress/AGENTS.md
+++ b/k8s/tyk-stack-ingress/AGENTS.md
@@ -26,7 +26,16 @@ helmfile -l version=lts apply
 
 # Deploy control plane only
 helmfile -l version=lts,tier=cp apply
+
+# Deploy one topology at a specific version (via the script, which resolves
+# images and writes the .ports.yaml/.images.yaml that helmfile reads)
+TOPOLOGY=master GW_IMAGE_TAG=release-5.8 DASH_IMAGE_TAG=release-5.8 \
+  IMAGE_REPO_TYPE=ecr ./run-tyk-cp-dp.sh toxiproxy=true
 ```
+
+Note: a bare `helmfile apply` needs `versions/<topo>/.ports.yaml` and
+`.images.yaml` to exist, so run `run-tyk-cp-dp.sh` at least once first. Helmfile
+also honours `TOPOLOGY` and skips the topologies it does not select.
 
 Create Kind cluster:
 ```bash
@@ -77,11 +86,37 @@ Required environment variables (set in `.env` file):
 
 Optional (configured in `versions/*/version.yaml`):
 - `imageRepo` - Docker registry (default: tykio, or ECR URL)
-- `dashTag` - Dashboard image tag (default: v5.12.0)
-- `gwTag` - Gateway image tag (default: v5.12.0)
+- `imageRepoType` - `official` or `ecr`; selects the image names to use
+- `dashTag` - Dashboard image tag
+- `gwTag` - Gateway image tag
+- `mdcbTag` - MDCB image tag
 - `numDataPlanes` - Number of data planes (default: 2)
+- `versionIndex` - Toxiproxy port band for this topology
 
-ECR images require AWS credentials and `ecrcred` secret creation.
+Optional environment variables, which override `version.yaml`:
+- `TOPOLOGY` - deploy only this `versions/<name>` topology (default: all of them)
+- `IMAGE_REPO`, `IMAGE_REPO_TYPE` - registry for gateway and dashboard
+- `GW_IMAGE_TAG`, `DASH_IMAGE_TAG` - gateway and dashboard tags
+- `MDCB_IMAGE_REPO`, `MDCB_IMAGE_REPO_TYPE`, `MDCB_IMAGE_TAG` - MDCB, which
+  versions independently and usually stays on an official release while the
+  gateway and dashboard move
+
+Exporting any image override requires `TOPOLOGY`, since one set of tags cannot
+describe several version lines - the script fails rather than applying them
+everywhere. The same values read from `.env` are treated as local defaults: used
+when one topology is selected, skipped with a warning otherwise.
+
+`run-tyk-cp-dp.sh` resolves these into `versions/<topo>/.images.yaml` (gitignored,
+like `.ports.yaml`) and logs every effective image; `helmfile.yaml.gotmpl` reads
+that file rather than `version.yaml`. Keeping resolution in one place is what
+stops the script's ECR setup and the helm render from disagreeing - and the tags
+being unreadable from helmfile is what made the CI version matrix silently inert
+(TT-17949).
+
+ECR images require AWS credentials. The script creates the `ecrcred` secret and
+attaches it to the `default` ServiceAccount in the control plane namespace *and*
+each data plane namespace - the DP gateways pull the same private image, and no
+Tyk chart here enables a dedicated ServiceAccount.
 
 Toxiproxy agent CLI location: `../apps/toxiproxy-agent/cli.py`
 

--- a/k8s/tyk-stack-ingress/helmfile.yaml.gotmpl
+++ b/k8s/tyk-stack-ingress/helmfile.yaml.gotmpl
@@ -16,33 +16,47 @@ repositories:
 ---
 {{- $versionsDir := "./versions" }}
 {{- $versionEntries := readDirEntries $versionsDir }}
+{{- /*
+  TOPOLOGY restricts this state to a single versions/<name> directory. Empty
+  means every topology, which is the default for local multi-version work.
+  Skipping here is required, not just an optimisation: run-tyk-cp-dp.sh only
+  writes .ports.yaml/.images.yaml for the topologies it selected, and the
+  readFile calls below are evaluated at template time for every topology this
+  loop reaches - an unselected one would fail the render on a missing file.
+*/}}
+{{- $selected := env "TOPOLOGY" | default "" }}
 
 releases:
   {{- range $entry := $versionEntries }}
   {{- if $entry.IsDir }}
   {{- $name := $entry.Name }}
+  {{- if or (eq $selected "") (eq $selected $name) }}
   {{- $versionPath := printf "%s/%s/version.yaml" $versionsDir $name }}
   {{- $versionContent := readFile $versionPath }}
   {{- $config := $versionContent | fromYaml }}
   {{- $cpNamespace := printf "tyk-%s" $name }}
-  {{- $gwTag := default "v5.8.9" (index $config "gwTag") }}
-  {{- $dashTag := default "v5.8.9" (index $config "dashTag") }}
-  {{- $mdcbTag := default "v2.8.0" (index $config "mdcbTag") }}
   {{- $numDP := default 2 (index $config "numDataPlanes") }}
-  {{- $imageRepo := default "tykio" (index $config "imageRepo") }}
-  {{- $imageRepoType := default "official" (index $config "imageRepoType") }}
   {{- $useToxiproxy := $.Values.useToxiproxy | default false }}
   {{- $portsPath := printf "%s/%s/.ports.yaml" $versionsDir $name }}
   {{- $ports := readFile $portsPath | fromYaml }}
 
-  {{- $gwImageName := "tyk-gateway" }}
-  {{- $dashImageName := "tyk-dashboard" }}
-  {{- $mdcbImageName := "tyk-mdcb-docker" }}
-  {{- if eq $imageRepoType "ecr" }}
-    {{- $gwImageName = "tyk-ee" }}
-    {{- $dashImageName = "tyk-analytics" }}
-    {{- $mdcbImageName = "tyk-sink" }}
-  {{- end }}
+  {{- /*
+    Images come from .images.yaml, which run-tyk-cp-dp.sh writes by applying the
+    IMAGE_REPO, GW_IMAGE_TAG, DASH_IMAGE_TAG and MDCB_IMAGE_ env overrides on
+    top of version.yaml. Resolution lives there rather than here so the script's
+    ECR setup and this render cannot disagree about which registry is in play,
+    and so the effective versions are logged and left on disk. Reading tags
+    straight from version.yaml is what made the CI version matrix inert: the
+    env vars the workflow exported were never consulted. TT-17949
+  */}}
+  {{- $imagesPath := printf "%s/%s/.images.yaml" $versionsDir $name }}
+  {{- $images := readFile $imagesPath | fromYaml }}
+  {{- $gwRepository := index $images "gwRepository" }}
+  {{- $gwTag := index $images "gwTag" }}
+  {{- $dashRepository := index $images "dashRepository" }}
+  {{- $dashTag := index $images "dashTag" }}
+  {{- $mdcbRepository := index $images "mdcbRepository" }}
+  {{- $mdcbTag := index $images "mdcbTag" }}
 
   - name: redis-{{ $name }}
     chart: tyk-helm/simple-redis
@@ -128,15 +142,15 @@ releases:
       - name: tyk-mdcb.mdcb.license
         value: {{ $.Values.tykMdcbLicense }}
       - name: tyk-gateway.gateway.image.repository
-        value: {{ $imageRepo }}/{{ $gwImageName }}
+        value: {{ $gwRepository }}
       - name: tyk-gateway.gateway.image.tag
         value: {{ $gwTag }}
       - name: tyk-dashboard.dashboard.image.repository
-        value: {{ $imageRepo }}/{{ $dashImageName }}
+        value: {{ $dashRepository }}
       - name: tyk-dashboard.dashboard.image.tag
         value: {{ $dashTag }}
       - name: tyk-mdcb.mdcb.image.repository
-        value: {{ $imageRepo }}/{{ $mdcbImageName }}
+        value: {{ $mdcbRepository }}
       - name: tyk-mdcb.mdcb.image.tag
         value: {{ $mdcbTag }}
         {{- if $useToxiproxy }}
@@ -239,7 +253,7 @@ releases:
       - name: global.secrets.useSecretName
         value: tyk-data-plane-secret
       - name: tyk-gateway.gateway.image.repository
-        value: {{ $imageRepo }}/{{ $gwImageName }}
+        value: {{ $gwRepository }}
       - name: tyk-gateway.gateway.image.tag
         value: {{ $gwTag }}
         {{- if $useToxiproxy }}
@@ -261,6 +275,7 @@ releases:
         value: {{ $dpNum }}
     wait: true
 
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- end }}{{/* range dpIndex */}}
+  {{- end }}{{/* if topology selected */}}
+  {{- end }}{{/* if entry.IsDir */}}
+  {{- end }}{{/* range versionEntries */}}

--- a/k8s/tyk-stack-ingress/readme.md
+++ b/k8s/tyk-stack-ingress/readme.md
@@ -17,16 +17,57 @@ Export licenses to environment variables (or save them in .env file or rename .e
   ```
 </details>
 
-### [optional] Choose Docker image
-You can choose Dashboard and Gateway Docker images you want to use in your env.
+### [optional] Choose which topology to deploy
+The stack is defined as a set of *topologies* under `versions/`, one directory per
+version line (`lts`, `stable`, `master`). Each gets its own namespaces
+(`tyk-<topology>`, `tyk-<topology>-dp-<n>`), ingress hosts and Toxiproxy port band.
 
-*If you want to use different tag* -> set proper value in *DASH_IMAGE_TAG* and *GW_IMAGE_TAG* env variables (or save it in .env file).
+By default every topology is deployed. Set *TOPOLOGY* to deploy just one:
+```
+TOPOLOGY=master ./run-tyk-cp-dp.sh
+```
+CI sets this, because a job that only talks to one control plane should not pay
+for the other two.
+
+### [optional] Choose Docker image
+You can choose Dashboard, Gateway and MDCB Docker images you want to use in your env.
+The defaults live in `versions/<topology>/version.yaml` (`gwTag`, `dashTag`,
+`mdcbTag`, `imageRepo`, `imageRepoType`); the env variables below override them.
+
+*If you want to use different tag* -> set *DASH_IMAGE_TAG* / *GW_IMAGE_TAG* /
+*MDCB_IMAGE_TAG* (or save them in .env file).
 
 *If you want to use private ECR repo* -> set *IMAGE_REPO* env variable (or save it in .env file). Warning: login to AWS needed! [Instruction on how to login](https://tyktech.atlassian.net/wiki/spaces/~554878896/pages/1881243669/How+to+deploy+a+local+Developer+Experience+environment+DX). This allows to use unofficial images like *master*, *pr-XXXX*, etc.
+An ECR host is recognised from its `*.dkr.ecr.*.amazonaws.com` form, so the image
+names are switched to their ECR equivalents (`tyk-ee`, `tyk-analytics`,
+`tyk-sink`) automatically. Set *IMAGE_REPO_TYPE* to `ecr` or `official`
+explicitly if you need to override that.
 Command to login to ECR
 ```
 aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 754489498669.dkr.ecr.eu-central-1.amazonaws.com
 ```
+
+**Overrides apply to one topology.** Because a single set of tags cannot describe
+several version lines, exporting any of them requires *TOPOLOGY* as well:
+```
+TOPOLOGY=master IMAGE_REPO_TYPE=ecr GW_IMAGE_TAG=release-5.8 DASH_IMAGE_TAG=release-5.8 ./run-tyk-cp-dp.sh
+```
+Without *TOPOLOGY* the script stops rather than stamping one version over every
+topology. Values that come from `.env` are treated as local defaults instead: they
+are applied when a single topology is selected, and skipped with a warning
+otherwise.
+
+MDCB versions independently of the gateway and dashboard - there is no
+`release-5.8` MDCB build - so it has its own *MDCB_IMAGE_REPO*,
+*MDCB_IMAGE_REPO_TYPE* and *MDCB_IMAGE_TAG*. Use them to hold MDCB on an official
+release while gateway and dashboard move:
+```
+MDCB_IMAGE_REPO_TYPE=official MDCB_IMAGE_TAG=v2.8.8
+```
+
+The resolved images are logged at the start of every run and written to
+`versions/<topology>/.images.yaml`, so you can always tell what was actually
+deployed rather than what was requested.
 
 ## Starting Control Plane and Data Planes
 1. Provide Licenses (as described above)

--- a/k8s/tyk-stack-ingress/run-tyk-cp-dp.sh
+++ b/k8s/tyk-stack-ingress/run-tyk-cp-dp.sh
@@ -6,6 +6,25 @@ cd "$(dirname "$0")"
 SCRIPT_DIR="$(pwd)"
 source lib.sh
 
+# Snapshot the image overrides the caller exported, before .env is sourced.
+#
+# .env assigns these unconditionally, so sourcing it would otherwise clobber
+# what CI passed in. The two sources also carry different intent, and are
+# treated differently below: an exported value is a deliberate, per-run choice
+# and must name the topology it applies to, while a .env value is a local
+# default that cannot say which of several topologies it meant.
+#
+# Before TT-17949 neither source was honoured at all - helmfile read tags
+# straight out of versions/<topo>/version.yaml.
+ENV_TOPOLOGY="${TOPOLOGY:-}"
+ENV_IMAGE_REPO="${IMAGE_REPO:-}"
+ENV_IMAGE_REPO_TYPE="${IMAGE_REPO_TYPE:-}"
+ENV_GW_IMAGE_TAG="${GW_IMAGE_TAG:-}"
+ENV_DASH_IMAGE_TAG="${DASH_IMAGE_TAG:-}"
+ENV_MDCB_IMAGE_REPO="${MDCB_IMAGE_REPO:-}"
+ENV_MDCB_IMAGE_REPO_TYPE="${MDCB_IMAGE_REPO_TYPE:-}"
+ENV_MDCB_IMAGE_TAG="${MDCB_IMAGE_TAG:-}"
+
 if [ -f .env ]; then
   source .env
 fi
@@ -31,6 +50,50 @@ INGRESS_READY_TIMEOUT="${INGRESS_READY_TIMEOUT:-90s}"
 TOOLS_NAMESPACE="tools"
 TYK_PRO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 VERSIONS_DIR="${SCRIPT_DIR}/versions"
+ECR_REGISTRY="${ECR_REGISTRY:-754489498669.dkr.ecr.eu-central-1.amazonaws.com}"
+ECR_REGION="${ECR_REGION:-eu-central-1}"
+
+# TOPOLOGY restricts the deployment to a single versions/<name> directory.
+# Unset (the default) deploys every topology, which is what local multi-version
+# work wants. CI sets it, because a job that only ever talks to one control
+# plane has no use for the other two and pays for them in cluster capacity.
+TOPOLOGY="${ENV_TOPOLOGY:-${TOPOLOGY:-}}"
+
+# Image overrides. These win over the gwTag/dashTag/imageRepo fields in
+# versions/<topo>/version.yaml, and apply to the selected topology only.
+#
+# They exist so a caller can hold the topology *name* fixed - every namespace,
+# service DNS name and ingress host is derived from it, so changing the name
+# breaks the test environment's addressing - while swapping the images
+# underneath. That is how the CI version matrix tests an LTS branch without
+# renaming half the cluster.
+#
+# MDCB has its own trio because it versions independently of gateway and
+# dashboard: there is no "release-5.8" MDCB build to line up with a 5.8
+# gateway, so it usually needs to stay on an official tag while gw/dash move.
+#
+# A caller-exported value wins over .env, which is the opposite of what plain
+# sourcing does - see the snapshot above.
+IMAGE_REPO="${ENV_IMAGE_REPO:-${IMAGE_REPO:-}}"
+IMAGE_REPO_TYPE="${ENV_IMAGE_REPO_TYPE:-${IMAGE_REPO_TYPE:-}}"
+GW_IMAGE_TAG="${ENV_GW_IMAGE_TAG:-${GW_IMAGE_TAG:-}}"
+DASH_IMAGE_TAG="${ENV_DASH_IMAGE_TAG:-${DASH_IMAGE_TAG:-}}"
+MDCB_IMAGE_REPO="${ENV_MDCB_IMAGE_REPO:-${MDCB_IMAGE_REPO:-}}"
+MDCB_IMAGE_REPO_TYPE="${ENV_MDCB_IMAGE_REPO_TYPE:-${MDCB_IMAGE_REPO_TYPE:-}}"
+MDCB_IMAGE_TAG="${ENV_MDCB_IMAGE_TAG:-${MDCB_IMAGE_TAG:-}}"
+
+# Whether any override was exported by the caller rather than read from .env.
+# Only these force the TOPOLOGY requirement in resolveImages.
+OVERRIDES_EXPORTED="no"
+for _v in "$ENV_IMAGE_REPO" "$ENV_IMAGE_REPO_TYPE" "$ENV_GW_IMAGE_TAG" \
+  "$ENV_DASH_IMAGE_TAG" "$ENV_MDCB_IMAGE_REPO" "$ENV_MDCB_IMAGE_REPO_TYPE" \
+  "$ENV_MDCB_IMAGE_TAG"; do
+  if [ -n "$_v" ]; then
+    OVERRIDES_EXPORTED="yes"
+    break
+  fi
+done
+unset _v
 
 USE_TOXIPROXY="false"
 for param in "$@"; do
@@ -42,6 +105,8 @@ done
 export USE_TOXIPROXY
 export TYK_DB_LICENSEKEY
 export TYK_MDCB_LICENSEKEY
+# helmfile.yaml.gotmpl reads this to skip topologies this run did not select.
+export TOPOLOGY
 
 ######################################
 # functions
@@ -56,6 +121,178 @@ read_version_field() {
   local value
   value=$(grep "^${field}:" "$version_file" 2> /dev/null | awk '{print $2}' || true)
   echo "${value:-$default}"
+}
+
+# selectedTopologies - print the versions/<name> directories this run deploys.
+# Honours TOPOLOGY; prints every topology when it is unset. Every per-topology
+# loop goes through here so the selection cannot drift between the ECR setup,
+# the port computation, the helmfile apply and the labelling.
+selectedTopologies() {
+  local found=0
+  local topo_dir topo
+  for topo_dir in "$VERSIONS_DIR"/*/; do
+    [ -d "$topo_dir" ] || continue
+    [ -f "${topo_dir}version.yaml" ] || continue
+    topo=$(basename "$topo_dir")
+    if [ -n "$TOPOLOGY" ] && [ "$topo" != "$TOPOLOGY" ]; then
+      continue
+    fi
+    echo "$topo_dir"
+    found=1
+  done
+  if [ "$found" -eq 0 ]; then
+    # stderr, so a caller capturing this function's stdout gets directory names
+    # only and never mistakes a diagnostic for a topology.
+    if [ -n "$TOPOLOGY" ]; then
+      error "TOPOLOGY='$TOPOLOGY' matches no directory under $VERSIONS_DIR" >&2
+    else
+      error "No topologies with a version.yaml found under $VERSIONS_DIR" >&2
+    fi
+    return 1
+  fi
+}
+
+# looks_like_ecr <repo> - true for an ECR registry host.
+# readme.md tells developers to set IMAGE_REPO alone to switch to the private
+# registry, so the repo type has to be inferable from the host. Without this an
+# ECR host gets paired with the public image names and every pull 404s.
+looks_like_ecr() {
+  case "${1:-}" in
+    *.dkr.ecr.*.amazonaws.com*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# image_repo_for <repo_type> <repo> - the registry to pull from.
+# ECR needs an explicit host; the official images live under the tykio org.
+image_repo_for() {
+  local repo_type="${1:?repo type required}"
+  local repo="${2:-}"
+  if [ -n "$repo" ]; then
+    echo "$repo"
+  elif [ "$repo_type" = "ecr" ]; then
+    echo "$ECR_REGISTRY"
+  else
+    echo "tykio"
+  fi
+}
+
+# image_name_for <component> <repo_type> - repository name within the registry.
+# The ECR builds are published under different names than the public images.
+image_name_for() {
+  local component="${1:?component required}"
+  local repo_type="${2:?repo type required}"
+  case "$component" in
+    gw) [ "$repo_type" = "ecr" ] && echo "tyk-ee" || echo "tyk-gateway" ;;
+    dash) [ "$repo_type" = "ecr" ] && echo "tyk-analytics" || echo "tyk-dashboard" ;;
+    mdcb) [ "$repo_type" = "ecr" ] && echo "tyk-sink" || echo "tyk-mdcb-docker" ;;
+    *)
+      error "Unknown image component '$component'"
+      return 1
+      ;;
+  esac
+}
+
+# resolveImages - write versions/<topo>/.images.yaml for each selected topology.
+#
+# version.yaml supplies the defaults; the IMAGE_* env vars override them. The
+# result is written to disk rather than passed to helmfile as flags for the same
+# reason .ports.yaml is: helmfile reads it back per topology, and a file on disk
+# is inspectable after the fact. Every effective image is logged, because the
+# failure this guards against - deploying a version other than the one asked
+# for - is otherwise completely silent. TT-17949
+resolveImages() {
+  local overrides_set="" name
+  for name in IMAGE_REPO IMAGE_REPO_TYPE GW_IMAGE_TAG DASH_IMAGE_TAG \
+    MDCB_IMAGE_REPO MDCB_IMAGE_REPO_TYPE MDCB_IMAGE_TAG; do
+    if [ -n "${!name}" ]; then
+      overrides_set="${overrides_set:+$overrides_set }$name"
+    fi
+  done
+
+  # Resolve the selection once. Capturing it also surfaces a bad TOPOLOGY as a
+  # failure here rather than letting the later process-substitution loops, whose
+  # exit status is invisible, quietly iterate over nothing.
+  local topos topo_count
+  topos=$(selectedTopologies) || return 1
+  topo_count=$(printf '%s\n' "$topos" | grep -c . || true)
+
+  # Applying one set of tags to several topologies would silently stamp, say, a
+  # master build over the lts topology. When the overrides were exported for
+  # this run, that is a mistake worth stopping for. When they merely came from
+  # .env - which cannot express which topology it meant - drop them and carry
+  # on with each version.yaml, which is exactly what happened before these
+  # overrides were wired up, so no local workflow changes behaviour.
+  if [ -n "$overrides_set" ] && [ -z "$TOPOLOGY" ] && [ "$topo_count" -gt 1 ]; then
+    if [ "$OVERRIDES_EXPORTED" = "yes" ]; then
+      error "Image overrides ($overrides_set) are set but TOPOLOGY is not, and $topo_count topologies are selected."
+      error "Set TOPOLOGY=<name> to say which topology the overrides apply to."
+      return 1
+    fi
+    warning "Ignoring image overrides from .env ($overrides_set): $topo_count topologies are selected and .env cannot say which one it meant."
+    warning "Set TOPOLOGY=<name> to apply them to a single topology."
+    IMAGE_REPO=""
+    IMAGE_REPO_TYPE=""
+    GW_IMAGE_TAG=""
+    DASH_IMAGE_TAG=""
+    MDCB_IMAGE_REPO=""
+    MDCB_IMAGE_REPO_TYPE=""
+    MDCB_IMAGE_TAG=""
+  fi
+
+  local topo_dir topo version_file
+  while read -r topo_dir; do
+    [ -n "$topo_dir" ] || continue
+    topo=$(basename "$topo_dir")
+    version_file="${topo_dir}version.yaml"
+
+    local base_repo_type base_repo
+    base_repo_type="${IMAGE_REPO_TYPE:-$(read_version_field "$version_file" "imageRepoType" "official")}"
+    base_repo="${IMAGE_REPO:-$(read_version_field "$version_file" "imageRepo" "")}"
+    # An ECR host with no explicit type means ECR - see looks_like_ecr.
+    if [ -z "$IMAGE_REPO_TYPE" ] && looks_like_ecr "$base_repo"; then
+      base_repo_type="ecr"
+    fi
+
+    local mdcb_repo_type mdcb_repo
+    mdcb_repo_type="${MDCB_IMAGE_REPO_TYPE:-$base_repo_type}"
+    mdcb_repo="${MDCB_IMAGE_REPO:-}"
+    if [ -z "$MDCB_IMAGE_REPO_TYPE" ] && looks_like_ecr "$mdcb_repo"; then
+      mdcb_repo_type="ecr"
+    fi
+    # Only inherit the shared repo when the type still matches it, otherwise an
+    # ECR host would be paired with an official image name.
+    if [ -z "$mdcb_repo" ] && [ "$mdcb_repo_type" = "$base_repo_type" ]; then
+      mdcb_repo="$base_repo"
+    fi
+
+    local gw_tag dash_tag mdcb_tag
+    gw_tag="${GW_IMAGE_TAG:-$(read_version_field "$version_file" "gwTag" "v5.8.9")}"
+    dash_tag="${DASH_IMAGE_TAG:-$(read_version_field "$version_file" "dashTag" "v5.8.9")}"
+    mdcb_tag="${MDCB_IMAGE_TAG:-$(read_version_field "$version_file" "mdcbTag" "v2.8.0")}"
+
+    local gw_image dash_image mdcb_image
+    gw_image="$(image_repo_for "$base_repo_type" "$base_repo")/$(image_name_for gw "$base_repo_type")"
+    dash_image="$(image_repo_for "$base_repo_type" "$base_repo")/$(image_name_for dash "$base_repo_type")"
+    mdcb_image="$(image_repo_for "$mdcb_repo_type" "$mdcb_repo")/$(image_name_for mdcb "$mdcb_repo_type")"
+
+    local images_file="${topo_dir}.images.yaml"
+    {
+      echo "gwRepository:   $gw_image"
+      echo "gwTag:          $gw_tag"
+      echo "dashRepository: $dash_image"
+      echo "dashTag:        $dash_tag"
+      echo "mdcbRepository: $mdcb_image"
+      echo "mdcbTag:        $mdcb_tag"
+      echo "repoType:       $base_repo_type"
+      echo "mdcbRepoType:   $mdcb_repo_type"
+    } > "$images_file"
+
+    log "Resolved images for topology '$topo':"
+    log "    gateway   $gw_image:$gw_tag"
+    log "    dashboard $dash_image:$dash_tag"
+    log "    mdcb      $mdcb_image:$mdcb_tag"
+  done < <(printf '%s\n' "$topos")
 }
 
 deployNginx() {
@@ -166,12 +403,12 @@ labelDataPlaneServices() {
 #
 # Port bands ensure isolation between concurrent multi-version deployments.
 computePorts() {
-  for topo_dir in "$VERSIONS_DIR"/*/; do
-    [ -d "$topo_dir" ] || continue
+  local topo_dir
+  while read -r topo_dir; do
+    [ -n "$topo_dir" ] || continue
     local topo
     topo=$(basename "$topo_dir")
     local version_file="${topo_dir}version.yaml"
-    [ -f "$version_file" ] || continue
 
     local VI
     VI=$(read_version_field "$version_file" "versionIndex" "0")
@@ -196,7 +433,7 @@ computePorts() {
     } > "$ports_file"
 
     log "Computed ports for $topo (versionIndex=$VI) -> $ports_file"
-  done
+  done < <(selectedTopologies)
 }
 
 # precreateToxiProxyProxies - Create proxies before services exist
@@ -219,13 +456,13 @@ precreateToxiProxyProxies() {
     pip install -q -r "$requirements_path" 2> /dev/null || true
   fi
 
-  for topo_dir in "$VERSIONS_DIR"/*/; do
-    [ -d "$topo_dir" ] || continue
+  local topo_dir
+  while read -r topo_dir; do
+    [ -n "$topo_dir" ] || continue
     local topo
     topo=$(basename "$topo_dir")
 
     local version_file="${topo_dir}version.yaml"
-    [ -f "$version_file" ] || continue
 
     local ports_file="${topo_dir}.ports.yaml"
     if [ ! -f "$ports_file" ]; then
@@ -245,7 +482,7 @@ precreateToxiProxyProxies() {
       --num-data-planes "$num_dps" \
       --toxiproxy-namespace "toxiproxy" \
       --verbose
-  done
+  done < <(selectedTopologies)
 
   log "Toxiproxy proxies pre-created successfully"
 }
@@ -269,8 +506,9 @@ populateToxiProxy() {
     pip install -q -r "$requirements_path" 2> /dev/null || true
   fi
 
-  for topo_dir in "$VERSIONS_DIR"/*/; do
-    [ -d "$topo_dir" ] || continue
+  local topo_dir
+  while read -r topo_dir; do
+    [ -n "$topo_dir" ] || continue
     local topo
     topo=$(basename "$topo_dir")
 
@@ -280,7 +518,7 @@ populateToxiProxy() {
       --control-namespace "tyk-${topo}" \
       --toxiproxy-namespace "toxiproxy" \
       --verbose
-  done
+  done < <(selectedTopologies)
 
   log "Toxiproxy configured successfully"
 }
@@ -305,41 +543,59 @@ if [ "$USE_TOXIPROXY" = "true" ]; then
   }
 fi
 
-# ECR pre-steps: iterate versions and set up private registry access where needed
-for topo_dir in "$VERSIONS_DIR"/*/; do
-  [ -d "$topo_dir" ] || continue
+# resolve the effective image for every selected topology before anything is
+# deployed, so the ECR setup below and helmfile both read the same answer
+log "Resolving images for selected topologies..."
+resolveImages || {
+  error "failed to resolve images"
+  exit 1
+}
+
+# ECR pre-steps: set up private registry access for topologies that need it.
+# The pull secret has to exist in the data plane namespaces as well as the
+# control plane one - the DP gateways pull the same private gateway image, and
+# helmfile's postsync hook creates those namespaces too late for us to patch
+# them afterwards, so create them up front. Namespace creation is idempotent
+# and the hook re-applies its own secret into them later. TT-17949
+while read -r topo_dir; do
+  [ -n "$topo_dir" ] || continue
   topo=$(basename "$topo_dir")
   version_file="${topo_dir}version.yaml"
-  [ -f "$version_file" ] || continue
+  images_file="${topo_dir}.images.yaml"
 
-  IMAGE_REPO_TYPE=$(read_version_field "$version_file" "imageRepoType" "official")
-  if [[ "$IMAGE_REPO_TYPE" == "ecr" ]]; then
-    IMAGE_REPO=$(read_version_field "$version_file" "imageRepo" "tykio")
-    MDCB_IMAGE_TAG=$(read_version_field "$version_file" "mdcbTag" "v2.8.0")
-    MDCB_IMAGE_NAME="tyk-sink"
-    MDCB_VALIDATION_IMAGE_TAG="v10.0.0"
-    CP_NS="tyk-${topo}"
+  repo_type=$(read_version_field "$images_file" "repoType" "official")
+  mdcb_repo_type=$(read_version_field "$images_file" "mdcbRepoType" "official")
+  if [[ "$repo_type" != "ecr" && "$mdcb_repo_type" != "ecr" ]]; then
+    continue
+  fi
 
-    log "Setting up ECR access for version $topo in namespace $CP_NS"
-    kubectl create namespace "$CP_NS" 2> /dev/null || true
+  num_dps=$(read_version_field "$version_file" "numDataPlanes" "2")
+  ecr_namespaces=("tyk-${topo}")
+  for i in $(seq 1 "$num_dps"); do
+    ecr_namespaces+=("tyk-${topo}-dp-${i}")
+  done
 
-    kubectl -n "$CP_NS" create secret docker-registry ecrcred \
-      --docker-server=754489498669.dkr.ecr.eu-central-1.amazonaws.com \
+  log "Setting up ECR access for topology $topo in: ${ecr_namespaces[*]}"
+  ecr_password="$(aws ecr get-login-password --region "$ECR_REGION")"
+  for ns in "${ecr_namespaces[@]}"; do
+    kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
+
+    kubectl -n "$ns" create secret docker-registry ecrcred \
+      --docker-server="$ECR_REGISTRY" \
       --docker-username=AWS \
-      --docker-password="$(aws ecr get-login-password --region eu-central-1)" \
+      --docker-password="$ecr_password" \
       --dry-run=client -o yaml | kubectl apply -f -
 
-    kubectl -n "$CP_NS" patch sa default -p '{"imagePullSecrets":[{"name":"ecrcred"}]}' || true
-
-    log "Pulling MDCB image for ECR version $topo"
-    docker pull "$IMAGE_REPO/$MDCB_IMAGE_NAME:$MDCB_IMAGE_TAG"
-    docker tag "$IMAGE_REPO/$MDCB_IMAGE_NAME:$MDCB_IMAGE_TAG" "$IMAGE_REPO/$MDCB_IMAGE_NAME:$MDCB_VALIDATION_IMAGE_TAG"
-    kind load docker-image "$IMAGE_REPO/$MDCB_IMAGE_NAME:$MDCB_VALIDATION_IMAGE_TAG" --name kind
-  fi
-done
+    # The gateway, dashboard and mdcb charts all run under the namespace's
+    # default ServiceAccount (none of them enables a dedicated one), so
+    # attaching the secret here covers every Tyk pod.
+    kubectl -n "$ns" patch sa default -p '{"imagePullSecrets":[{"name":"ecrcred"}]}' || true
+  done
+  unset ecr_password
+done < <(selectedTopologies)
 
 # pre-compute toxiproxy ports for each version before helmfile apply
-log "Pre-computing toxiproxy ports for all versions..."
+log "Pre-computing toxiproxy ports for selected topologies..."
 computePorts
 
 # pre-create toxiproxy proxies before helmfile apply (predictive mode)
@@ -351,22 +607,30 @@ if [ "$USE_TOXIPROXY" = "true" ]; then
   }
 fi
 
-# deploy all versions via helmfile
-log "Deploying all versions via Helmfile..."
+# deploy the selected versions via helmfile
+if [ -n "$TOPOLOGY" ]; then
+  log "Deploying topology '$TOPOLOGY' via Helmfile..."
+else
+  log "Deploying all versions via Helmfile..."
+fi
 HELMFILE_ARGS=()
 if [ "$USE_TOXIPROXY" = "true" ]; then
   HELMFILE_ARGS+=(--state-values-set "useToxiproxy=true")
+fi
+if [ -n "$TOPOLOGY" ]; then
+  # The template already skips unselected topologies; the label selector keeps
+  # helm itself from touching releases outside the selection.
+  HELMFILE_ARGS+=(-l "version=$TOPOLOGY")
 fi
 
 helmfile apply -q --suppress-diff --concurrency=0 "${HELMFILE_ARGS[@]+"${HELMFILE_ARGS[@]}"}"
 log "Helmfile apply completed"
 
 # label services and namespaces for toxiproxy/resilience test discovery (per version)
-for topo_dir in "$VERSIONS_DIR"/*/; do
-  [ -d "$topo_dir" ] || continue
+while read -r topo_dir; do
+  [ -n "$topo_dir" ] || continue
   topo=$(basename "$topo_dir")
   version_file="${topo_dir}version.yaml"
-  [ -f "$version_file" ] || continue
 
   NUM_DPS=$(read_version_field "$version_file" "numDataPlanes" "2")
   VI=$(read_version_field "$version_file" "versionIndex" "0")
@@ -399,7 +663,7 @@ for topo_dir in "$VERSIONS_DIR"/*/; do
       tyk.io/toxiproxy-port-redis="$DP_REDIS_PORT" \
       --overwrite > /dev/null
   done
-done
+done < <(selectedTopologies)
 
 # tools namespace
 log "Creating $TOOLS_NAMESPACE namespace"


### PR DESCRIPTION
## Description

`helmfile.yaml.gotmpl` resolved every image from `versions/<topo>/version.yaml`, so the `IMAGE_REPO` / `DASH_IMAGE_TAG` / `GW_IMAGE_TAG` variables that tyk-analytics' `k8s-api-tests` workflow exports were read by **nothing**. `readme.md` documented them as working.

`run-tyk-cp-dp.sh` now resolves images itself and writes the result to `versions/<topo>/.images.yaml` (gitignored, mirroring `.ports.yaml`), which helmfile reads instead of `version.yaml`. `version.yaml` still supplies the defaults; these override them:

| Variable | Applies to |
|---|---|
| `IMAGE_REPO`, `IMAGE_REPO_TYPE` | gateway + dashboard registry |
| `GW_IMAGE_TAG`, `DASH_IMAGE_TAG` | gateway + dashboard tags |
| `MDCB_IMAGE_REPO`, `MDCB_IMAGE_REPO_TYPE`, `MDCB_IMAGE_TAG` | MDCB, independently |
| `TOPOLOGY` | which `versions/<name>` to deploy |

Resolution lives in the script rather than the template so its ECR setup and the helm render cannot disagree about which registry is in play. Every effective image is logged, because deploying the wrong version was previously silent.

MDCB gets its own trio because it versions independently — there is no `release-5.8` MDCB build to pair with a 5.8 gateway, so it needs to stay on an official release while gateway and dashboard move.

Overrides apply to **one** topology, named by `TOPOLOGY`, which also restricts the deployment to that topology.

## Motivation and Context

tyk-analytics' scheduled `k8s-api-tests` matrix claims to test `master`, `release-5.13` and `release-5.8`. All three legs deployed `versions/master/version.yaml` — dashboard and gateway **v5.11.1**, MDCB v2.8.8 — and passed green. From the `release-5.8` leg's own collected pod logs:

```
Tyk Analytics Dashboard 5.11.1
Tyk API Gateway 5.11.1        (CP gw, DP-1 gw, both DP-2 gw pods)
Starting Tyk DC Bridge v2.8.8
```

So there was **no LTS coverage at all**, and the "master" leg tested a released v5.11.1 rather than master. This surfaced while investigating a resilience test that appeared to fail only on 5.8 — it turned out every leg was running the same stack, and the test was simply flaky (fixed separately in TykTechnologies/tyk-analytics#6134).

`TOPOLOGY` also addresses the cost side: with no filter, every run built three control planes plus six data planes and the tests used one.

## Also fixed along the way

- **ECR pull secrets were control-plane only.** The DP gateways pull the same private image, so `ecrcred` and the `default` ServiceAccount patch are now applied to the DP namespaces too. No Tyk chart here enables a dedicated ServiceAccount, so patching `default` covers every pod. This path had never actually run, since all three topologies are `official`.
- **An ECR host with no explicit type used the public image names**, producing pulls for `<ecr>/tyk-gateway` instead of `<ecr>/tyk-ee`. The type is now inferred from the `*.dkr.ecr.*.amazonaws.com` host, which is what `readme.md` tells developers to rely on.
- **`selectedTopologies` writes diagnostics to stderr**, so a caller capturing its stdout cannot mistake an error message for a topology name.

## How This Has Been Tested

**Backwards compatibility — the important one.** With no overrides exported, `helmfile build` output is **byte-identical** to the previous template across all three topologies:

```
$ git stash push -- helmfile.yaml.gotmpl   # original
$ helmfile build --skip-deps > before.yaml
$ git stash pop                            # this PR
$ helmfile build --skip-deps > after.yaml
$ diff before.yaml after.yaml && echo IDENTICAL
IDENTICAL
```

lts=v5.8.12, master=v5.11.1, stable=v5.12.0, MDCB v2.8.8/v2.9.0, all `tykio` — unchanged.

**The fix working.** `TOPOLOGY=master IMAGE_REPO_TYPE=ecr GW_IMAGE_TAG=release-5.8 DASH_IMAGE_TAG=release-5.8 MDCB_IMAGE_REPO_TYPE=official MDCB_IMAGE_TAG=v2.8.8` renders:

```
tyk-gateway.gateway.image.repository:     <ecr>/tyk-ee          (CP + both DP gateways)
tyk-gateway.gateway.image.tag:            release-5.8
tyk-dashboard.dashboard.image.repository: <ecr>/tyk-analytics
tyk-dashboard.dashboard.image.tag:        release-5.8
tyk-mdcb.mdcb.image.repository:           tykio/tyk-mdcb-docker
tyk-mdcb.mdcb.image.tag:                  v2.8.8
```

with zero `tyk-lts` / `tyk-stable` releases, and only `versions/master/` getting `.ports.yaml` and `.images.yaml`.

**Resolution scenarios**, exercised against a real local `.env` that sets `IMAGE_REPO` (ECR) and `master` tags:

| Scenario | Result |
|---|---|
| No exported overrides, 3 topologies | warns, ignores `.env`, deploys today's images |
| `TOPOLOGY=master` + ECR branch tags | `tyk-ee` / `tyk-analytics` at `release-5.8`, MDCB official |
| Exported override, no `TOPOLOGY` | fails with a message naming the variables |
| `TOPOLOGY=lts`, `.env` ECR host, no type | infers ECR → `tyk-ee`, was `tyk-gateway` |
| `TOPOLOGY=nope` | fails; previously the diagnostic was counted as a topology |

`bash -n` clean. `shellcheck` was not available in my environment — worth a pass before merge.

**Not verified locally, no AWS credentials here** (`UnrecognizedClientException`): that the ECR tags `tyk-analytics:release-5.8` and `tyk-ee:release-5.8` exist, and that a 5.8 data plane is happy against MDCB 2.8.8. The first CI run on the consuming PR will settle both. `versions/lts` already pairs v5.8.12 with v2.8.8, so the second has precedent.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **`main` branch** (left side).
- [x] My change requires a change to the documentation — `readme.md` and `AGENTS.md` updated in this PR.
- [x] All new and existing tests passed.

## Consumer

Needs TykTechnologies/tyk-analytics#6135, which passes `TOPOLOGY: master` and asserts the deployed image tags match the requested leg. Merge this first — that assertion fails until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
